### PR TITLE
Add k8s port forward on test to communicate kas-dev env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,16 @@
 version: 2.1
+orbs:
+  aws-eks: circleci/aws-eks@1.0.2
 
 executors:
   default:
     docker:
     - image: circleci/node:10.15.3
     working_directory: ~/caver-js-ext-kas
+  test_machine:
+    machine:
+      image: ubuntu-1604:202007-01
+    working_directory: ~/caver-java-ext-kas
 
 commands:
   notify-success:
@@ -38,6 +44,16 @@ jobs:
     executor: default
     steps:
       - checkout
+      - aws-eks/update-kubeconfig-with-authenticator:
+          cluster-name: ${EKS_CLUSTER_NAME}
+          install-kubectl: true
+          cluster-context-alias: test-cluster
+      - run:
+          command: |
+            set -xoeu
+            echo "127.0.0.1 $KAS_BASEDOMAINS" | sudo tee -a /etc/hosts
+            kubectl port-forward service/$KAS_SERVICE 8888:80 -n $KAS_NAMESPACE
+          background: true
       - run: npm install
       - run: npm run test
 
@@ -135,6 +151,7 @@ workflows:
   build_and_test:
     jobs:
       - test:
+          context: kas_caver_test
           <<: *stage_default
       - build:
           <<: *stage_default


### PR DESCRIPTION
## Proposed changes

- Add k8s port forward before run test to connect to kas-dev env

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
