### PR TITLE
Added node version supporting test with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:carbon
+# FROM node:dubnium
+# FROM node:erbium
+# ENV NODE_VERSION 12.19.0
+
+# make app directory
+WORKDIR /usr/src/app
+
+# use wild card to copy both of package.json and package-lock.json
+COPY package*.json ./
+
+# install app dependencies
+RUN npm install && \
+    npm install -g mocha@6.2.2
+# install solc
+RUN curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.5.6/solc-static-linux \
+    && chmod u+x /usr/bin/solc
+
+# add app source
+COPY . .
+
+CMD npm test ; npm run intTest

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@babel/preset-env": "^7.11.0",
     "babel-eslint": "^8.2.6",
     "chai": "^4.2.0",
-    "mocha": "^8.1.3",
+    "mocha": "^6.2.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.5.1",
     "eslint-config-airbnb": "^17.0.0",


### PR DESCRIPTION
## Proposed changes

This Dockerfile let you test with various Node versions.

And also, to support Node v8, mocha should be downgraded.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
