### PR TITLE
Removed type module in package.json file to use require

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "webpack": "^4.43.0",
     "webpack-cli": "^3.3.12"
   },
-  "type": "module",
   "devDependencies": {
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
## Proposed changes

This PR introduces remove `"type": "module"` to use require.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

refer https://github.com/standard-things/esm/issues/868
refer https://stackoverflow.com/questions/61401475/why-is-type-module-in-package-json-file
refer https://stackoverflow.com/questions/37132031/node-js-plans-to-support-import-export-es6-ecmascript-2015-modules