### PR TITLE
Return error object when ErrorResponse is came

### DIFF
--- a/src/rest-client/src/ApiClient.js
+++ b/src/rest-client/src/ApiClient.js
@@ -515,7 +515,7 @@
                     }
                 } else if (response && Object.keys(response.body).length > 0) {
                     error = null
-                    data = ErrorResponse.constructFromObject(response.body)
+                    error = ErrorResponse.constructFromObject(response.body)
                 }
                 callback(error, data, response)
             }


### PR DESCRIPTION
## Proposed changes

This PR introduces the contents of passing an error to callback when an ErrorResponse from KAS comes as a response.

Previously, ErrorResponse was also processed as data, but in this case, it is more difficult to handle errors, so change to throw as an error in case of ErrorRseponse.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [ ] New feature or enhancement
- [x] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
