### PR TITLE
Added more logic to handle legacy tx and other exceptions

### DIFF
--- a/test/wallet/testKASWallet.js
+++ b/test/wallet/testKASWallet.js
@@ -282,7 +282,7 @@ describe('caver.wallet with KASWallet', () => {
             expect(getRLPEncodingSpy.callCount).to.equal(1)
             expect(basicRawRequestStub.callCount).to.equal(1)
             expect(fdRawRequestSpy.called).not.to.be.true
-            expect(appendSignaturesSpy.callCount).to.equal(1)
+            expect(appendSignaturesSpy.called).not.to.be.true
             expect(signed.signatures.length).to.equal(1)
         }).timeout(50000)
 
@@ -334,7 +334,7 @@ describe('caver.wallet with KASWallet', () => {
             expect(getRLPEncodingSpy.callCount).to.equal(1)
             expect(fdRawRequestStub.callCount).to.equal(1)
             expect(basicRawRequestSpy.called).not.to.be.true
-            expect(appendSignaturesSpy.callCount).to.equal(1)
+            expect(appendSignaturesSpy.called).not.to.be.true
             expect(signed.signatures.length).to.equal(1)
         }).timeout(50000)
 
@@ -418,7 +418,7 @@ describe('caver.wallet with KASWallet', () => {
             expect(getRLPEncodingSpy.callCount).to.equal(1)
             expect(basicRawRequestStub.callCount).to.equal(1)
             expect(fdRawRequestSpy.called).not.to.be.true
-            expect(appendSignaturesSpy.callCount).to.equal(1)
+            expect(appendSignaturesSpy.called).not.to.be.true
             expect(signed.signatures.length).to.equal(1)
         }).timeout(50000)
 
@@ -448,7 +448,7 @@ describe('caver.wallet with KASWallet', () => {
             expect(getRLPEncodingSpy.callCount).to.equal(1)
             expect(basicRawRequestStub.callCount).to.equal(1)
             expect(fdRawRequestSpy.called).not.to.be.true
-            expect(appendSignaturesSpy.callCount).to.equal(1)
+            expect(appendSignaturesSpy.called).not.to.be.true
             expect(signed.signatures.length).to.equal(1)
         }).timeout(50000)
     })
@@ -761,11 +761,20 @@ describe('caver.wallet with KASWallet', () => {
             expect(signed.feePayerSignatures.length).to.equal(1)
         }).timeout(50000)
 
-        it('CAVERJS-EXT-KAS-WALLET-198: caver.wallet.signAsGlobalFeePayer throw error when fee payer is defined in transaction', async () => {
-            tx.feePayer = feePayerAddress
+        it('CAVERJS-EXT-KAS-WALLET-198: caver.wallet.signAsGlobalFeePayer throw error when fee payer address is different', async () => {
+            // Define different fee payer address in transaction
+            tx.feePayer = caver.wallet.keyring.generate().address
 
-            const expectedError = `To sign the transaction using the global fee payer, feePayer cannot be defined in the transaction.`
+            const fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
+            const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')
+            const fdRawRequestStub = sandbox.stub(caver.wallet.walletAPI, 'requestFDRawTransactionPaidByGlobalFeePayer')
+            fdRawRequestStub.resolves(resultOfSigning)
+
+            const expectedError = `Invalid fee payer: The address of the fee payer defined in the transaction does not match the address of the global fee payer. To sign with a global fee payer, you must define the global fee payer's address in the feePayer field, or the feePayer field must not be defined.`
             await expect(caver.wallet.signAsGlobalFeePayer(tx)).to.be.rejectedWith(expectedError)
+            expect(fillTransactionSpy.callCount).to.equal(1)
+            expect(getRLPEncodingSpy.callCount).to.equal(1)
+            expect(fdRawRequestStub.callCount).to.equal(1)
         }).timeout(50000)
 
         it('CAVERJS-EXT-KAS-WALLET-199: caver.wallet.signAsGlobalFeePayer throw error when parameter is invalid', async () => {


### PR DESCRIPTION
## Proposed changes

This PR contains some additional logic in kasWallet.

- Added default number(1) with `caver.wallet.generate`
- When checking accountKey, if accountKey is null, accountKey is not checked.
- Exception handling has been added so that legacy transactions can also be used.
- When using a global fee, the logic has been changed to allow appending feePayerSignatures. The existing logic of `signAsGlobalFeePayer` returned an error if the fee payer was defined in the transaction, but the logic was added/modified to operate to be able to append for the same global fee payer.

After this PR in mergered, i will upload integration test PR.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
