### PR TITLE
Keyring can be accessed by keyringContainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ const caver = new CaverExtKAS()
 const keyringContainer = new caver.keyringContainer()
 
 // Create a keyring from private key
-const keyring = caver.wallet.keyring.createFromPrivateKey('0x{private key}')
+const keyring = keyringContainer.keyring.createFromPrivateKey('0x{private key}')
 
 // Add a keyring to the keyringContainer
 keyringContainer.add(keyring)

--- a/index.js
+++ b/index.js
@@ -57,7 +57,17 @@ class CaverExtKAS extends Caver {
         // `caver.wallet` in CaverExtKAS is a KASWallet that internally connects the KAS Wallet API
         const kasWallet = new KASWallet(this.kas.wallet)
         kasWallet.keyring = this.wallet.keyring
-        this.keyringContainer = this.wallet.constructor
+
+        const _this = this
+        class KeyringContainer extends this.wallet.constructor {
+            constructor(keyrings) {
+                super(keyrings)
+                this.keyring = _this.wallet.keyring
+            }
+        }
+
+        this.keyringContainer = KeyringContainer
+        this.keyringContainer.keyring = this.wallet.keyring
         this.wallet = kasWallet
 
         if (chainId !== undefined && accessKeyId && secretAccessKey) this.initKASAPI(chainId, accessKeyId, secretAccessKey)

--- a/test/intTest/kasWalletIntTest.js
+++ b/test/intTest/kasWalletIntTest.js
@@ -62,7 +62,7 @@ const input =
     '0xe942b5160000000000000000000000000000000000000000000000000000000000000040000000000000000000000000000000000000000000000000000000000000008000000000000000000000000000000000000000000000000000000000000000036b65790000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000576616c7565000000000000000000000000000000000000000000000000000000'
 
 async function sendTestKLAY(to, klay = 1) {
-    const keyring = caver.wallet.keyring.createFromPrivateKey(senderPrivateKey)
+    const keyring = caver.keyringContainer.keyring.createFromPrivateKey(senderPrivateKey)
     const vt = new caver.transaction.valueTransfer({
         from: keyring.address,
         to,
@@ -126,7 +126,7 @@ describe('KAS Wallet', () => {
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-118: caver.wallet.getAccount rejects if account is not existed in KAS Wallet API Service', async () => {
-        await expect(caver.wallet.getAccount(caver.wallet.keyring.generate().address)).to.be.rejectedWith(`data don't exist`)
+        await expect(caver.wallet.getAccount(caver.keyringContainer.keyring.generate().address)).to.be.rejectedWith(`data don't exist`)
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-119: caver.wallet.isExisted returns true if account is existed in KAS Wallet API Service', async () => {
@@ -135,7 +135,7 @@ describe('KAS Wallet', () => {
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-120: caver.wallet.isExisted returns false if account is not existed in KAS Wallet API Service', async () => {
-        const isExist = await caver.wallet.isExisted(caver.wallet.keyring.generate().address)
+        const isExist = await caver.wallet.isExisted(caver.keyringContainer.keyring.generate().address)
         expect(isExist).to.be.false
     }).timeout(500000)
 
@@ -151,7 +151,7 @@ describe('KAS Wallet', () => {
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-122: caver.wallet.remove rejects if use tried to remove an account which is not existed in KAS Wallet API Service', async () => {
-        await expect(caver.wallet.remove(caver.wallet.keyring.generate().address)).to.be.rejectedWith(`data don't exist`)
+        await expect(caver.wallet.remove(caver.keyringContainer.keyring.generate().address)).to.be.rejectedWith(`data don't exist`)
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-123: caver.wallet.disableAccount deactivates an account in KAS Wallet API Service', async () => {
@@ -172,7 +172,7 @@ describe('KAS Wallet', () => {
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-124: caver.wallet.disableAccount rejects if use tried to deactivate an account which is not existed in KAS Wallet API Service', async () => {
-        await expect(caver.wallet.disableAccount(caver.wallet.keyring.generate().address)).to.be.rejectedWith(
+        await expect(caver.wallet.disableAccount(caver.keyringContainer.keyring.generate().address)).to.be.rejectedWith(
             `account has been already deleted or disabled`
         )
     }).timeout(500000)
@@ -196,7 +196,7 @@ describe('KAS Wallet', () => {
     }).timeout(500000)
 
     it('CAVERJS-EXT-KAS-INT-126: caver.wallet.enableAccount rejects if use tried to activate an account which is not existed in KAS Wallet API Service', async () => {
-        await expect(caver.wallet.enableAccount(caver.wallet.keyring.generate().address)).to.be.rejectedWith(
+        await expect(caver.wallet.enableAccount(caver.keyringContainer.keyring.generate().address)).to.be.rejectedWith(
             `account has been already deleted or enabled`
         )
     }).timeout(500000)
@@ -328,7 +328,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-135: caver.wallet.sign signs the smart contract deploy transaction with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.smartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
         })
@@ -340,7 +340,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-136: caver.wallet.sign appends signatures to the smart contract deploy transaction', async () => {
         const tx = new caver.transaction.smartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
             signatures: [
@@ -549,7 +549,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-149: caver.wallet.sign signs the fee delegated smart contract deploy transaction with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
         })
@@ -562,7 +562,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-150: caver.wallet.sign appends signatures to the fee delegated smart contract deploy transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
             signatures: [
@@ -784,7 +784,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-163: caver.wallet.sign signs the fee delegated smart contract deploy with ratio transaction with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -798,7 +798,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-164: caver.wallet.sign appends signatures to the fee delegated smart contract deploy with ratio transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -1037,7 +1037,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-177: caver.wallet.signAsFeePayer signs the fee delegated smart contract deploy transaction as fee payer with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
         })
@@ -1052,7 +1052,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-178: caver.wallet.signAsFeePayer appends feePayerSignatures to the fee delegated smart contract deploy transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
             feePayer,
@@ -1307,7 +1307,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-191: caver.wallet.signAsFeePayer signs the fee delegated smart contract deploy with ratio transaction as fee payer with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -1323,7 +1323,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-192: caver.wallet.signAsFeePayer appends feePayerSignatures to the fee delegated smart contract deploy with ratio transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -1559,7 +1559,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-205: caver.wallet.signAsGlobalFeePayer signs the fee delegated smart contract deploy transaction as fee payer with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
         })
@@ -1574,7 +1574,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-206: caver.wallet.signAsGlobalFeePayer appends feePayerSignatures to the fee delegated smart contract deploy transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecution({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             input,
         })
@@ -1780,7 +1780,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-219: caver.wallet.signAsGlobalFeePayer signs the fee delegated smart contract deploy with ratio transaction as fee payer with the account in KAS Wallet API Service', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -1796,7 +1796,7 @@ describe('KAS Wallet', () => {
     it('CAVERJS-EXT-KAS-INT-220: caver.wallet.signAsGlobalFeePayer appends feePayerSignatures to the fee delegated smart contract deploy with ratio transaction', async () => {
         const tx = new caver.transaction.feeDelegatedSmartContractExecutionWithRatio({
             from,
-            to: caver.wallet.keyring.generate().address,
+            to: caver.keyringContainer.keyring.generate().address,
             gas: 50000,
             feeRatio: 50,
             input,
@@ -1947,7 +1947,7 @@ describe('KAS Wallet', () => {
 
     it('CAVERJS-EXT-KAS-INT-230: caver.contract execute KIP-7 contract with an account in KAS Wallet API Service', async () => {
         const kip7 = new caver.kct.kip7(kip7Address)
-        const receipt = await kip7.transfer(caver.wallet.keyring.generate().address, 1, { from })
+        const receipt = await kip7.transfer(caver.keyringContainer.keyring.generate().address, 1, { from })
 
         expect(receipt.from.toLowerCase()).to.equal(from)
         expect(receipt.to.toLowerCase()).to.equal(kip7Address)

--- a/test/intTest/tokenHistoryIntTest.js
+++ b/test/intTest/tokenHistoryIntTest.js
@@ -84,7 +84,7 @@ describe('TokenHistory API service', () => {
         caver.initTokenHistoryAPI(chainId, accessKeyId, secretAccessKey, url)
         caver.initNodeAPI(nodeAPIEnv.chainId, nodeAPIEnv.accessKeyId, nodeAPIEnv.secretAccessKey, nodeAPIEnv.url)
 
-        sender = keyringContainer.add(caver.wallet.keyring.createFromPrivateKey(senderPrivateKey))
+        sender = keyringContainer.add(keyringContainer.keyring.createFromPrivateKey(senderPrivateKey))
 
         createTestTokenContracts(sender).then(() => done())
     })

--- a/test/intTest/walletIntTest.js
+++ b/test/intTest/walletIntTest.js
@@ -130,7 +130,7 @@ describe('Wallet API service', () => {
         caver.initNodeAPI(auths.nodeAPI.chainId, auths.nodeAPI.accessKeyId, auths.nodeAPI.secretAccessKey, auths.nodeAPI.url)
         caver.initWalletAPI(chainId, accessKeyId, secretAccessKey, url)
 
-        senderKeyring = keyringContainer.add(caver.wallet.keyring.createFromPrivateKey(senderPrivateKey))
+        senderKeyring = keyringContainer.add(keyringContainer.keyring.createFromPrivateKey(senderPrivateKey))
     })
 
     it('CAVERJS-EXT-KAS-INT-018: caver.kas.wallet.createAccount should create account in KAS wallet API service', async () => {

--- a/test/nodeAPI/testNodeAPI.js
+++ b/test/nodeAPI/testNodeAPI.js
@@ -87,7 +87,7 @@ describe('Node API service', () => {
         caver.initNodeAPI(chainId, accessKeyId, secretAccessKey, url)
 
         if (senderPrivateKey !== '0x') {
-            sender = keyringContainer.add(caver.wallet.keyring.createFromPrivateKey(senderPrivateKey))
+            sender = keyringContainer.add(keyringContainer.keyring.createFromPrivateKey(senderPrivateKey))
             testAddress = sender.address
         }
 

--- a/test/wallet/testKASWallet.js
+++ b/test/wallet/testKASWallet.js
@@ -56,7 +56,7 @@ describe('caver.wallet with KASWallet', () => {
             expect(caver.wallet.keyring).not.to.be.undefined
         }).timeout(50000)
 
-        it('CAVERJS-EXT-KAS-WALLET-202: caver.wallet.keyring should be available', () => {
+        it('CAVERJS-EXT-KAS-WALLET-202: keyring can be accessed through keyringContainer', () => {
             const keyringContainer = new caver.keyringContainer()
             expect(keyringContainer.keyring).not.to.be.undefined
         }).timeout(50000)
@@ -768,7 +768,7 @@ describe('caver.wallet with KASWallet', () => {
 
         it('CAVERJS-EXT-KAS-WALLET-198: caver.wallet.signAsGlobalFeePayer throw error when fee payer address is different', async () => {
             // Define different fee payer address in transaction
-            tx.feePayer = caver.wallet.keyring.generate().address
+            tx.feePayer = caver.keyringContainer.keyring.generate().address
 
             const fillTransactionSpy = sandbox.spy(tx, 'fillTransaction')
             const getRLPEncodingSpy = sandbox.spy(tx, 'getRLPEncoding')

--- a/test/wallet/testKASWallet.js
+++ b/test/wallet/testKASWallet.js
@@ -55,6 +55,11 @@ describe('caver.wallet with KASWallet', () => {
         it('CAVERJS-EXT-KAS-WALLET-171: caver.wallet.keyring should be available', () => {
             expect(caver.wallet.keyring).not.to.be.undefined
         }).timeout(50000)
+
+        it('CAVERJS-EXT-KAS-WALLET-202: caver.wallet.keyring should be available', () => {
+            const keyringContainer = new caver.keyringContainer()
+            expect(keyringContainer.keyring).not.to.be.undefined
+        }).timeout(50000)
     })
 
     context('caver.wallet.generate', () => {


### PR DESCRIPTION
## Proposed changes

This PR introduces the addition of the Keyring module to be accessed through an instance of KeyringContainer. Also you can access keyring through `caver.keyringContainer`

The usability of the existing `caver.wallet.keyring` is maintained, but it is unnatural to access Keyring through KASWallet.
So, if the user uses keyringContainer separately, i will guide user to access the keyring module through the keyringContainer instance.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
