### PR TITLE
Update to set chain id to header with Node api

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ class CaverExtKAS extends Caver {
         this._requestManager.provider.headers = this._requestManager.provider.headers || []
         const auth = [
             { name: 'Authorization', value: `Basic ${Buffer.from(`${accessKeyId}:${secretAccessKey}`).toString('base64')}` },
-            { name: 'x-krn', value: `krn:${chainId}:node` },
+            { name: 'x-chain-id', value: chainId },
         ]
         this._requestManager.provider.headers = this._requestManager.provider.headers.concat(auth)
     }

--- a/test/nodeAPI/testNodeAPI.js
+++ b/test/nodeAPI/testNodeAPI.js
@@ -70,8 +70,8 @@ describe('Node API service enabling', () => {
             const headers = caver._requestManager.provider.headers
             expect(headers[0].name).to.equal('Authorization')
             expect(headers[0].value).to.equal(`Basic ${Buffer.from(`${accessKeyId}:${secretAccessKey}`).toString('base64')}`)
-            expect(headers[1].name).to.equal('x-krn')
-            expect(headers[1].value).to.equal(`krn:${chainId}:node`)
+            expect(headers[1].name).to.equal('x-chain-id')
+            expect(headers[1].value).to.equal(chainId)
         })
     })
 })


### PR DESCRIPTION
## Proposed changes

This PR introduces set `x-chain-id` in the header instead of `x-krn`

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
