### PR TITLE
Convert number string to hex string

### DIFF
--- a/src/kas/kip17/kip17.js
+++ b/src/kas/kip17/kip17.js
@@ -244,7 +244,7 @@ class KIP17 {
         if (!_.isString(tokenURI)) throw new Error(`The token URI should be string type.`)
         if (!_.isString(tokenId) && !_.isNumber(tokenId)) throw new Error(`The token Id should be hexadecimal string or number type.`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         const opts = {
             body: MintKip17TokenRequest.constructFromObject({ to, uri: tokenURI, id: tokenId }),
@@ -319,7 +319,7 @@ class KIP17 {
         if (!_.isString(addressOrAlias)) throw new Error(`The address and alias of KIP-17 token contract should be string type.`)
         if (!_.isString(tokenId) && !_.isNumber(tokenId)) throw new Error(`The token Id should be hexadecimal string or number type.`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         return new Promise((resolve, reject) => {
             this.kip17Api.getToken(this.chainId, addressOrAlias, tokenId, (err, data, response) => {
@@ -362,7 +362,7 @@ class KIP17 {
         if (!utils.isAddress(owner)) throw new Error(`Invalid address format: ${owner}`)
         if (!utils.isAddress(to)) throw new Error(`Invalid address format: ${to}`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         const opts = {
             body: TransferKip17TokenRequest.constructFromObject({ sender, owner, to }),
@@ -403,7 +403,7 @@ class KIP17 {
         if (!_.isString(tokenId) && !_.isNumber(tokenId)) throw new Error(`The token Id should be hexadecimal string or number type.`)
         if (!utils.isAddress(from)) throw new Error(`Invalid address format: ${from}`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         const opts = {
             body: BurnKip17TokenRequest.constructFromObject({ from }),
@@ -448,7 +448,7 @@ class KIP17 {
         if (!utils.isAddress(from)) throw new Error(`Invalid address format: ${from}`)
         if (!utils.isAddress(to)) throw new Error(`Invalid address format: ${to}`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         const opts = {
             body: ApproveKip17TokenRequest.constructFromObject({ from, to }),
@@ -568,7 +568,7 @@ class KIP17 {
         if (!_.isString(addressOrAlias)) throw new Error(`The address and alias of KIP-17 token contract should be string type.`)
         if (!_.isString(tokenId) && !_.isNumber(tokenId)) throw new Error(`The token Id should be hexadecimal string or number type.`)
 
-        if (_.isNumber(tokenId)) tokenId = utils.toHex(tokenId)
+        tokenId = utils.toHex(tokenId)
 
         if (_.isFunction(queryOptions)) {
             callback = queryOptions


### PR DESCRIPTION
## Proposed changes

This PR introduces converting number string to hex string.
For example, convert '1' to '0x1'.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
