### PR TITLE
Added yaml formatter to use openapi 3.0 rest client code

### DIFF
--- a/yamlFormatting.sh
+++ b/yamlFormatting.sh
@@ -20,6 +20,22 @@ for i in ${DIRS};do
 			# Changed model name from exports to acutal
 			sed -i '' "s/ exports/ ${model}/g" $j
 
+			# The formatting below converts the code format so that it can be used in caver-js-ext-kas.
+			cnt=$(grep -o 'import' $j | wc -l)
+			cmp=0
+			if [ ${cnt} -gt ${cmp} ]; then
+				# Use class and exports and also format class variable using "ModelName.prototype.varName"
+				sed -i '' "s/export default class /class /g" $j
+				tac $j | awk '/    }/ && ! seen {print "}"; seen=1} {print}'  | tac > tmp && mv tmp $j
+				sed -i '' '$ s/}/module.exports = '${model}'/g' $j
+				sed -i '' "s/'\(.*\)' = \(.*\)/${model}.prototype.\1 = \2/g" $j
+
+				# Changed import to require
+				sed -i '' "s/import\(.*\);/import\1/g" $j
+				sed -i '' "s/import\(.*\)from \"\(.*\)\"/import\1from \'\2\'/g" $j
+				sed -i '' "s/import\(.*\)from \(.*\)/const\1= require(\2)/g" $j
+			fi
+
 			# Modified path
 			sed -i '' "s/'..\/ApiClient'/'..\/..\/ApiClient'/g" $j
 			sed -i '' "s/'ApiClient'/'..\/..\/ApiClient'/g" $j
@@ -60,6 +76,22 @@ for i in ${DIRS};do
 
 			# Format empty brace without newline
 			sed -i '' 'H;1h;$!d;x; s/{\n *}/{}/g' $j
+
+			# Use Object instead of wrong model for anyof to use Object
+			sed -i '' "s/\[AnyOfPageable\(.*\)SummaryItemsItems\]/\[Object\]/g" $j
+			sed -i '' "/AnyOfPageable\(.*\)ItemsItems.call(this)/D" $j
+			sed -i '' "s/{Models\(.*\)Yaml}/{Object}/g" $j
+			sed -i '' "s/\(.*\)Models\(.*\)Yaml.constructFromObject(\(.*\))/\1ApiClient.convertToType(\3, Object)/g" $j
+			sed -i '' "/Models\(.*\)Yaml/D" $j
+
+			# Modify invalid 'ModelObject'
+			sed -i '' "/const ModelObject/D" $j
+			sed -i '' "s/ApiClient.constructFromObject(data, obj, 'ModelObject')/ApiClient.constructFromObject(data, obj, Object)/g" $j
+			sed -i '' "s/{Array.<ModelObject>}/{Array.<Object>}/g" $j
+
+			# Use Object instead of unused AccountUpdateKey model
+			sed -i '' "s/\(.*\)AccountUpdateKey.constructFromObject(\(.*\))/\1ApiClient.convertToType(\2, Object)/g" $j
+
 		done
 
       cd ../../;
@@ -76,6 +108,20 @@ for i in ${DIRS};do
 
 			# Changed api name from exports to acutal
 			sed -i '' "s/ exports/ ${api}/g" $j
+
+			# The formatting below converts the code format so that it can be used in caver-js-ext-kas.
+			cnt=$(grep -o 'import' $j | wc -l)
+			cmp=0
+			if [ ${cnt} -gt ${cmp} ]; then
+				# Use class and exports and also format class variable using "ModelName.prototype.varName"
+				sed -i '' "s/export default class /class /g" $j
+				echo "module.exports = ${api}" >> $j
+
+				# Changed import to require
+				sed -i '' "s/import\(.*\);/import\1/g" $j
+				sed -i '' "s/import\(.*\)from \"\(.*\)\"/import\1from \'\2\'/g" $j
+				sed -i '' "s/import\(.*\)from \(.*\)/const\1= require(\2)/g" $j
+			fi
 
 			# Modified path
 			sed -i '' "s/'..\/ApiClient'/'..\/..\/ApiClient'/g" $j


### PR DESCRIPTION
## Proposed changes

This PR introduces adding formatting logic to use a rest-client code generated from openapi 3.0 yaml file.

If you generate rest-client code with openapi 3.0, syntax that cannot be used or code that generates an error is generated.
Convert these code into a right syntax that can be used in caver-js-ext-kas and add logic to fix the parts where errors occur.

I generated the rest-client code using openapi 3.0 yaml, and after executing this `yamlFormatting.sh` to convert the code, and then i checked the operation by executing `npm run intTestQA`.

There is no problem in connecting and operating with KAS, but some unit tests need to be modified, so i plan to revise them and post them in a anthoer PR later.

## Types of changes

Please put an x in the boxes related to your change.

- [ ] Bugfix
- [x] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
