### PR TITLE
Modified validation logic with URL compatible credential string

### DIFF
--- a/index.js
+++ b/index.js
@@ -215,7 +215,7 @@ class CaverExtKAS extends Caver {
      * @return {void}
      */
     initNodeAPIWithWebSocket(chainId, accessKeyId, secretAccessKey, url) {
-        const regex = /[ `!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/
+        const regex = /[ `!@#$%^&*()+[\]{};':"\\|,.<>/?~]/
         if (regex.test(accessKeyId) || regex.test(secretAccessKey))
             throw new Error(
                 `Invalid auth: To use the websocket provider, you must use an accessKey and seretAccessKey that do not contain special characters. Please obtain a new AccessKey through the KAS Console.`

--- a/index.js
+++ b/index.js
@@ -215,8 +215,9 @@ class CaverExtKAS extends Caver {
      * @return {void}
      */
     initNodeAPIWithWebSocket(chainId, accessKeyId, secretAccessKey, url) {
-        const regex = /[ `!@#$%^&*()+[\]{};':"\\|,.<>/?~]/
-        if (regex.test(accessKeyId) || regex.test(secretAccessKey))
+        const regexForAccessKeyId = /^[A-Za-z0-9]+$/ // only A-Z, a-z, 0-9
+        const regexForSecretAccessKey = /^[^?=&+\s]+$/ // not allow to inclue ?, ,=,&,+
+        if (!regexForAccessKeyId.test(accessKeyId) || !regexForSecretAccessKey.test(secretAccessKey))
             throw new Error(
                 `Invalid auth: To use the websocket provider, you must use an accessKey and seretAccessKey that do not contain special characters. Please obtain a new AccessKey through the KAS Console.`
             )

--- a/test/nodeAPI/websocket.js
+++ b/test/nodeAPI/websocket.js
@@ -96,77 +96,83 @@ describe('caver.contract with websocket provider', () => {
         const expectedError =
             'Invalid auth: To use the websocket provider, you must use an accessKey and seretAccessKey that do not contain special characters. Please obtain a new AccessKey through the KAS Console.'
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}=`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}=`, pwd, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, `${id}[`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}[`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}]`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}]`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}$`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}$`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}_`, pwd, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, `${id}-`, pwd, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, `${id}~`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}_`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}?`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}~`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}<`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}?`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}\\`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}<`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}/`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}\\`, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id}?`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}/`, pwd)
-        }).to.throw(expectedError)
-        expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}?`, pwd)
-        }).to.throw(expectedError)
-        expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id} `, pwd)
+            caver.initNodeAPIWithWebSocket(chainId, `${id} `, pwd, url)
         }).to.throw(expectedError)
 
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}=`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}=`, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}[`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}[`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}]`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}]`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}$`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}$`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}_`, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}-`, url) // =, -, _ will be allowed in credential
+        }).not.to.throw(expectedError)
+        expect(() => {
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}~`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}_`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}~`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}<`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}\\`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}<`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}/`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}\\`)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}/`)
-        }).to.throw(expectedError)
-        expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`)
-        }).to.throw(expectedError)
-        expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd} `)
+            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd} `, url)
         }).to.throw(expectedError)
 
         caver.currentProvider.connection.close()

--- a/test/nodeAPI/websocket.js
+++ b/test/nodeAPI/websocket.js
@@ -97,7 +97,7 @@ describe('caver.contract with websocket provider', () => {
             'Invalid auth: To use the websocket provider, you must use an accessKey and seretAccessKey that do not contain special characters. Please obtain a new AccessKey through the KAS Console.'
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}=`, pwd, url) // =, -, _ will be allowed in credential
-        }).not.to.throw(expectedError)
+        }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}[`, pwd, url)
         }).to.throw(expectedError)
@@ -109,10 +109,10 @@ describe('caver.contract with websocket provider', () => {
         }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}_`, pwd, url) // =, -, _ will be allowed in credential
-        }).not.to.throw(expectedError)
+        }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}-`, pwd, url) // =, -, _ will be allowed in credential
-        }).not.to.throw(expectedError)
+        }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}~`, pwd, url)
         }).to.throw(expectedError)
@@ -129,24 +129,21 @@ describe('caver.contract with websocket provider', () => {
             caver.initNodeAPIWithWebSocket(chainId, `${id}/`, pwd, url)
         }).to.throw(expectedError)
         expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, `${id}?`, pwd, url)
-        }).to.throw(expectedError)
-        expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, `${id} `, pwd, url)
         }).to.throw(expectedError)
 
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}=`, url) // =, -, _ will be allowed in credential
-        }).not.to.throw(expectedError)
+        }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}[`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}]`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}$`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}_`, url) // =, -, _ will be allowed in credential
         }).not.to.throw(expectedError)
@@ -155,22 +152,19 @@ describe('caver.contract with websocket provider', () => {
         }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}~`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`, url)
         }).to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}<`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}\\`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}/`, url)
-        }).to.throw(expectedError)
-        expect(() => {
-            caver.initNodeAPIWithWebSocket(chainId, id, `${pwd}?`, url)
-        }).to.throw(expectedError)
+        }).not.to.throw(expectedError)
         expect(() => {
             caver.initNodeAPIWithWebSocket(chainId, id, `${pwd} `, url)
         }).to.throw(expectedError)


### PR DESCRIPTION
## Proposed changes

This PR introduces modification of validation logic with URL compatible credential string.

## Types of changes

Please put an x in the boxes related to your change.

- [x] Bugfix
- [ ] New feature or enhancement
- [ ] Others

## Checklist

*Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.*

- [x] I have read the [CONTRIBUTING GUIDELINES](https://github.com/ground-x/caver-js-ext-kas/blob/master/CONTRIBUTING.md) doc
- [x] I have signed the [CLA](https://cla-assistant.io/ground-x/caver-js-ext-kas)
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Related issues

- Please leave the issue numbers or links related to this PR here.

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
